### PR TITLE
Fix aux action always targeting Aux 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'aux':
-			self.atem.setAuxSource(parseInt(opt.input), parseInt(opt.auxbus));
+			self.atem.setAuxSource(parseInt(opt.input), parseInt(opt.aux));
 			break;
 
 		case 'cut':


### PR DESCRIPTION
`opts.auxbus` is undefined, which meant `parseInt` interpreted it as NaN, which meant that `atem-connection` would apply its default value of `0`. This commit uses the correct property name of `opts.aux`.

This fixes the issue reported in https://github.com/nrkno/tv-automation-atem-connection/issues/14