### PR TITLE
Create custom feedbacks on single button using up to 4 sources to program

### DIFF
--- a/index.js
+++ b/index.js
@@ -524,6 +524,21 @@ class instance extends instance_skel {
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}
+		else if (feedback.type == 'preview_bg_2') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
+		else if (feedback.type == 'preview_bg_3') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
+		else if (feedback.type == 'preview_bg_4') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pgmSrc == parseInt(opt.input4))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
 		else if (feedback.type == 'program_bg') {
 			if (this.getME(opt.mixeffect).pgmSrc == parseInt(opt.input)) {
 				out = { color: opt.fg, bgcolor: opt.bg };
@@ -839,6 +854,192 @@ class instance extends instance_skel {
 					choices: this.CHOICES_ME.slice(0, this.model.MEs)
 				}
 			]
+		};
+		if (this.model.MEs >= 2) {
+			feedbacks['preview_bg_2'] = {
+				label: 'Change colors from two preview sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
+		};
+		if (this.model.MEs >= 3) {
+			feedbacks['preview_bg_3'] = {
+				label: 'Change colors from three preview sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 3',
+						id: 'input3',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect3',
+						label: 'M/E Option 3',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
+		};
+		if (this.model.MEs >= 4) {
+			feedbacks['preview_bg_4'] = {
+				label: 'Change colors from four preview sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 3',
+						id: 'input3',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect3',
+						label: 'M/E Option 3',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 4',
+						id: 'input4',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect4',
+						label: 'M/E Option 4',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
 		};
 		feedbacks['program_bg'] = {
 			label: 'Change colors from program',
@@ -1806,6 +2007,9 @@ class instance extends instance_skel {
 				this.setAtemModel(this.deviceModel, true);
 				this.checkFeedbacks('aux_bg');
 				this.checkFeedbacks('preview_bg');
+				this.checkFeedbacks('preview_bg_2');
+				this.checkFeedbacks('preview_bg_3');
+				this.checkFeedbacks('preview_bg_4');
 				this.checkFeedbacks('program_bg');
 				this.checkFeedbacks('program_bg_2');
 				this.checkFeedbacks('program_bg_3');
@@ -1904,6 +2108,9 @@ class instance extends instance_skel {
 
 				if (this.initDone === true) {
 					this.checkFeedbacks('preview_bg');
+					this.checkFeedbacks('preview_bg_2');
+					this.checkFeedbacks('preview_bg_3');
+					this.checkFeedbacks('preview_bg_4');
 				}
 				break;
 

--- a/index.js
+++ b/index.js
@@ -529,6 +529,21 @@ class instance extends instance_skel {
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}
+		else if (feedback.type == 'program_bg_2') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
+		else if (feedback.type == 'program_bg_3') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pgmSrc == parseInt(opt.input4))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
+		else if (feedback.type == 'program_bg_4') {
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pgmSrc == parseInt(opt.input4))){
+				out = { color: opt.fg, bgcolor: opt.bg };
+			}
+		}
 		else if (feedback.type == 'aux_bg') {
 			if (this.getAux(parseInt(opt.aux)).source == parseInt(opt.input)) {
 				out = { color: opt.fg, bgcolor: opt.bg };
@@ -856,6 +871,192 @@ class instance extends instance_skel {
 					choices: this.CHOICES_ME.slice(0, this.model.MEs)
 				}
 			]
+		};
+		if (this.model.MEs >= 2) {
+			feedbacks['program_bg_2'] = {
+				label: 'Change colors from two program sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
+		};
+		if (this.model.MEs >= 3) {
+			feedbacks['program_bg_3'] = {
+				label: 'Change colors from three program sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 3',
+						id: 'input3',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect3',
+						label: 'M/E Option 3',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
+		};
+		if (this.model.MEs >= 4) {
+			feedbacks['program_bg_4'] = {
+				label: 'Change colors from four program sources',
+				description: 'If the inputs specified are in use by program on the M/E stage specified, change colors of the bank',
+				options: [
+					{
+						type: 'colorpicker',
+						label: 'Foreground color',
+						id: 'fg',
+						default: this.rgb(255,255,255)
+					},
+					{
+						type: 'colorpicker',
+						label: 'Background color',
+						id: 'bg',
+						default: this.rgb(255,0,0)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 1',
+						id: 'input1',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect1',
+						label: 'M/E Option 1',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 2',
+						id: 'input2',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect2',
+						label: 'M/E Option 2',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 3',
+						id: 'input3',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect3',
+						label: 'M/E Option 3',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					},
+					{
+						type: 'dropdown',
+						label: 'Input Option 4',
+						id: 'input4',
+						default: 1,
+						choices: this.CHOICES_MESOURCES
+					},
+					{
+						type: 'dropdown',
+						id: 'mixeffect4',
+						label: 'M/E Option 4',
+						default: 0,
+						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+					}
+				]
+			};
 		};
 		feedbacks['aux_bg'] = {
 			label: 'Change colors from AUX bus',
@@ -1606,6 +1807,9 @@ class instance extends instance_skel {
 				this.checkFeedbacks('aux_bg');
 				this.checkFeedbacks('preview_bg');
 				this.checkFeedbacks('program_bg');
+				this.checkFeedbacks('program_bg_2');
+				this.checkFeedbacks('program_bg_3');
+				this.checkFeedbacks('program_bg_4');
 				this.checkFeedbacks('dsk_bg');
 				this.checkFeedbacks('dsk_source');
 				this.checkFeedbacks('usk_bg');
@@ -1686,6 +1890,9 @@ class instance extends instance_skel {
 
 				if (this.initDone === true) {
 					this.checkFeedbacks('program_bg');
+					this.checkFeedbacks('program_bg_2');
+					this.checkFeedbacks('program_bg_3');
+					this.checkFeedbacks('program_bg_4');
 				}
 				break;
 
@@ -1801,7 +2008,7 @@ class instance extends instance_skel {
 	 * @since 1.1.0
 	 */
 	setSource(id, useME, useAux, useMV, shortLabel, label) {
-		
+
 		var source = this.getSource(id);
 
 		// Use ATEM names if we got um

--- a/index.js
+++ b/index.js
@@ -525,17 +525,17 @@ class instance extends instance_skel {
 			}
 		}
 		else if (feedback.type == 'preview_bg_2') {
-			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2))){
+			if ((this.getME(opt.mixeffect1).pvwSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pvwSrc == parseInt(opt.input2))){
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}
 		else if (feedback.type == 'preview_bg_3') {
-			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3))){
+			if ((this.getME(opt.mixeffect1).pvwSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pvwSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pvwSrc == parseInt(opt.input3))){
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}
 		else if (feedback.type == 'preview_bg_4') {
-			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pgmSrc == parseInt(opt.input4))){
+			if ((this.getME(opt.mixeffect1).pvwSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pvwSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pvwSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pvwSrc == parseInt(opt.input4))){
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}
@@ -870,7 +870,7 @@ class instance extends instance_skel {
 						type: 'colorpicker',
 						label: 'Background color',
 						id: 'bg',
-						default: this.rgb(255,0,0)
+						default: this.rgb(0,255,0)
 					},
 					{
 						type: 'dropdown',
@@ -897,8 +897,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect2',
 						label: 'M/E Option 2',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 1,
+						choices: this.CHOICES_ME.slice(1, this.model.MEs)
 					}
 				]
 			};
@@ -918,7 +918,7 @@ class instance extends instance_skel {
 						type: 'colorpicker',
 						label: 'Background color',
 						id: 'bg',
-						default: this.rgb(255,0,0)
+						default: this.rgb(0,255,0)
 					},
 					{
 						type: 'dropdown',
@@ -980,7 +980,7 @@ class instance extends instance_skel {
 						type: 'colorpicker',
 						label: 'Background color',
 						id: 'bg',
-						default: this.rgb(255,0,0)
+						default: this.rgb(0,255,0)
 					},
 					{
 						type: 'dropdown',
@@ -1007,8 +1007,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect2',
 						label: 'M/E Option 2',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 1,
+						choices: this.CHOICES_ME.slice(1, this.model.MEs)
 					},
 					{
 						type: 'dropdown',
@@ -1021,8 +1021,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect3',
 						label: 'M/E Option 3',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 2,
+						choices: this.CHOICES_ME.slice(2, this.model.MEs)
 					},
 					{
 						type: 'dropdown',
@@ -1035,8 +1035,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect4',
 						label: 'M/E Option 4',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 3,
+						choices: this.CHOICES_ME.slice(3, this.model.MEs)
 					}
 				]
 			};
@@ -1115,8 +1115,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect2',
 						label: 'M/E Option 2',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 1,
+						choices: this.CHOICES_ME.slice(1, this.model.MEs)
 					}
 				]
 			};
@@ -1225,8 +1225,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect2',
 						label: 'M/E Option 2',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 1,
+						choices: this.CHOICES_ME.slice(1, this.model.MEs)
 					},
 					{
 						type: 'dropdown',
@@ -1239,8 +1239,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect3',
 						label: 'M/E Option 3',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 2,
+						choices: this.CHOICES_ME.slice(2, this.model.MEs)
 					},
 					{
 						type: 'dropdown',
@@ -1253,8 +1253,8 @@ class instance extends instance_skel {
 						type: 'dropdown',
 						id: 'mixeffect4',
 						label: 'M/E Option 4',
-						default: 0,
-						choices: this.CHOICES_ME.slice(0, this.model.MEs)
+						default: 3,
+						choices: this.CHOICES_ME.slice(3, this.model.MEs)
 					}
 				]
 			};

--- a/index.js
+++ b/index.js
@@ -535,7 +535,7 @@ class instance extends instance_skel {
 			}
 		}
 		else if (feedback.type == 'program_bg_3') {
-			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3)) && (this.getME(opt.mixeffect4).pgmSrc == parseInt(opt.input4))){
+			if ((this.getME(opt.mixeffect1).pgmSrc == parseInt(opt.input1)) && (this.getME(opt.mixeffect2).pgmSrc == parseInt(opt.input2)) && (this.getME(opt.mixeffect3).pgmSrc == parseInt(opt.input3))){
 				out = { color: opt.fg, bgcolor: opt.bg };
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atem",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"api_version": "1.0.0",
 	"description": "Blackmagic Design",
 	"keywords": [


### PR DESCRIPTION
This fixes https://github.com/bitfocus/companion-module-atem/issues/9
Everything is working well in my tests. The new options based on how many M/Es you have.
<img width="640" alt="2" src="https://user-images.githubusercontent.com/14942903/54893791-d4db2e00-4e8d-11e9-865b-c2f9a2a1fa15.png">
<img width="630" alt="3" src="https://user-images.githubusercontent.com/14942903/54893784-c5f47b80-4e8d-11e9-80e2-d15327d7c351.png">
<img width="625" alt="4" src="https://user-images.githubusercontent.com/14942903/54893785-c9880280-4e8d-11e9-8d69-b0cc83141491.png">
