### PR TITLE
feat: add tally feedback

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -32,7 +32,7 @@ import {
   AtemUSKPicker
 } from './input'
 import { ModelSpec } from './models'
-import { getDSK, getME, getMultiviewerWindow, getSuperSourceBox, getUSK } from './state'
+import { TallyBySource, getDSK, getME, getMultiviewerWindow, getSuperSourceBox, getUSK } from './state'
 import {
   assertUnreachable,
   calculateTransitionSelection,
@@ -65,7 +65,8 @@ export enum FeedbackId {
   TransitionRate = 'transitionRate',
   MediaPlayerSource = 'mediaPlayerSource',
   FadeToBlackIsBlack = 'fadeToBlackIsBlack',
-  FadeToBlackRate = 'fadeToBlackRate'
+  FadeToBlackRate = 'fadeToBlackRate',
+  Tally = 'tally'
 }
 
 export enum MacroFeedbackType {
@@ -96,6 +97,48 @@ function getOptColors(evt: CompanionFeedbackEvent) {
   return {
     color: Number(evt.options.fg),
     bgcolor: Number(evt.options.bg)
+  }
+}
+
+function tallyFeedbacks(instance: InstanceSkel<AtemConfig>, model: ModelSpec, state: AtemState, tally: TallyBySource) {
+  return {
+    [FeedbackId.Tally]: literal<Required<CompanionFeedback>>({
+      label: 'Change colors from tally',
+      description: 'If the input specified has an active tally light, change colors of the bank',
+      options: [
+        ForegroundPicker(instance.rgb(255, 255, 255)),
+        {
+          type: 'colorpicker',
+          label: 'Program background color',
+          id: 'bgPgm',
+          default: instance.rgb(255, 0, 0)
+        },
+        {
+          type: 'colorpicker',
+          label: 'Preview background color',
+          id: 'bgPvw',
+          default: instance.rgb(0, 255, 0)
+        },
+        AtemMESourcePicker(model, state, 0)
+      ],
+      callback: evt => {
+        const source = tally[Number(evt.options.input)]
+        if (source) {
+          if (source.program) {
+            return {
+              color: Number(evt.options.fg),
+              bgcolor: Number(evt.options.bgPgm)
+            }
+          } else if (source.preview) {
+            return {
+              color: Number(evt.options.fg),
+              bgcolor: Number(evt.options.bgPvw)
+            }
+          }
+        }
+        return {}
+      }
+    })
   }
 }
 
@@ -671,8 +714,14 @@ function dskFeedbacks(instance: InstanceSkel<AtemConfig>, model: ModelSpec, stat
   }
 }
 
-export function GetFeedbacksList(instance: InstanceSkel<AtemConfig>, model: ModelSpec, state: AtemState) {
+export function GetFeedbacksList(
+  instance: InstanceSkel<AtemConfig>,
+  model: ModelSpec,
+  state: AtemState,
+  tally: TallyBySource
+) {
   const feedbacks: { [id in FeedbackId]: Required<CompanionFeedback> | undefined } = {
+    ...tallyFeedbacks(instance, model, state, tally),
     ...previewFeedbacks(instance, model, state),
     ...programFeedbacks(instance, model, state),
     ...uskFeedbacks(instance, model, state),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Atem, AtemState } from 'atem-connection'
+import { Atem, AtemState, Commands } from 'atem-connection'
 import InstanceSkel = require('../../../instance_skel')
 import { CompanionActionEvent, CompanionConfigField, CompanionSystem } from '../../../instance_skel_types'
 import { GetActionsList, HandleAction } from './actions'
@@ -7,6 +7,7 @@ import { FeedbackId, GetFeedbacksList } from './feedback'
 import { UpgradeV2_2_0 } from './migrations'
 import { GetAutoDetectModel, GetModelSpec, GetParsedModelSpec, MODEL_AUTO_DETECT, ModelSpec } from './models'
 import { GetPresetsList } from './presets'
+import { TallyBySource } from './state'
 import {
   InitVariables,
   updateDSKVariable,
@@ -23,6 +24,7 @@ class AtemInstance extends InstanceSkel<AtemConfig> {
   private model: ModelSpec
   private atem: Atem
   private atemState: AtemState
+  private atemTally: TallyBySource
   private initDone: boolean
 
   /**
@@ -32,6 +34,7 @@ class AtemInstance extends InstanceSkel<AtemConfig> {
     super(system, id, config)
 
     this.atemState = new AtemState()
+    this.atemTally = {}
 
     this.model = GetModelSpec(this.getBestModelId() || MODEL_AUTO_DETECT) || GetAutoDetectModel()
     this.config.modelID = this.model.id + ''
@@ -135,11 +138,22 @@ class AtemInstance extends InstanceSkel<AtemConfig> {
   private updateCompanionBits() {
     InitVariables(this, this.model, this.atemState)
     this.setPresetDefinitions(GetPresetsList(this, this.model, this.atemState))
-    this.setFeedbackDefinitions(GetFeedbacksList(this, this.model, this.atemState))
+    this.setFeedbackDefinitions(GetFeedbacksList(this, this.model, this.atemState, this.atemTally))
     this.setActions(GetActionsList(this.model, this.atemState))
     this.checkFeedbacks()
   }
 
+  /**
+   * Handle tally packets
+   */
+  private processReceivedCommand(command: Commands.AbstractCommand) {
+    if (command instanceof Commands.TallyBySourceCommand) {
+      // The feedback holds a reference to the old object, so we need
+      // to update it in place
+      Object.assign(this.atemTally, command.properties)
+      this.checkFeedbacks(FeedbackId.Tally)
+    }
+  }
   /**
    * Handle ATEM state changes
    */
@@ -338,6 +352,7 @@ class AtemInstance extends InstanceSkel<AtemConfig> {
       // TODO - clear cached state after some timeout
     })
     this.atem.on('stateChanged', this.processStateChange.bind(this))
+    this.atem.on('receivedCommand', this.processReceivedCommand.bind(this))
 
     if (this.config.host) {
       this.atem.connect(this.config.host)

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { AtemState } from 'atem-connection'
+import { AtemState, Commands } from 'atem-connection'
 import { InputValue } from '../../../instance_skel_types'
 
 // TODO - these should be exported more cleanly from atem-connection
@@ -6,6 +6,7 @@ type MixEffect = AtemState['video']['ME'][0]
 type UpstreamKeyer = MixEffect['upstreamKeyers'][0]
 type DownstreamKeyer = AtemState['video']['downstreamKeyers'][0]
 type MultiViewer = AtemState['settings']['multiViewers'][0]
+export type TallyBySource = Commands.TallyBySourceCommand['properties']
 
 export function getME(state: AtemState, meIndex: InputValue | undefined): MixEffect | undefined {
   return state.video.ME[Number(meIndex)]


### PR DESCRIPTION
Add a feedback mechanism that sets colors to mimic tally.

The default configuration is a Television Studio-style red + green on the same button. If you want separate program and preview tally, you can set one of the background colors to black.